### PR TITLE
Potential fix for code scanning alert no. 1: Double escaping or unescaping

### DIFF
--- a/src/views/SubjectView.vue
+++ b/src/views/SubjectView.vue
@@ -53,11 +53,11 @@ onUnmounted(() => {
 function decodeHtmlEntities(str) {
   return str
     .replace(/&#(\d+);/g, (match, dec) => String.fromCharCode(dec))
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'");
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
 }
 
 const decodedName = computed(() => {


### PR DESCRIPTION
Potential fix for [https://github.com/markni/netabare/security/code-scanning/1](https://github.com/markni/netabare/security/code-scanning/1)

To fix the double unescaping error, we must change the order in which HTML entities are decoded so that the ampersand (`&amp;`) is decoded last, not first. This prevents a situation where an entity like `&amp;quot;` is first decoded into `&quot;` (thus losing information about its original encoding), then further decoded into `"` which is wrong.

In file `src/views/SubjectView.vue`:
- Locate the `decodeHtmlEntities` function (lines 53-61).
- Reorder the `.replace()` calls so that replacements for `&lt;`, `&gt;`, `&quot;`, `&apos;`, and the numeric entities occur before the replacement of `&amp;`.

No external libraries are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
