### PR TITLE
feat: restyle and simplify global header navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -85,13 +85,13 @@ console.log(`
 
     <div
       id="main"
-      class="flex min-h-screen flex-col paper font-serif text-black sm:flex-row dark:text-white"
+      class="flex min-h-screen flex-col paper font-serif text-black dark:text-white"
     >
       <GlobalHeader />
-      <div :class="['bottom-0 container mx-auto w-full p-4 pt-10']">
+      <div :class="['bottom-0 container mx-auto w-full p-4 pt-6']">
         <RouterView />
       </div>
-      <div class="sticky top-10 right-10 hidden self-start sm:flex">
+      <div class="fixed right-6 bottom-6 z-20 hidden sm:flex">
         <EclipseToggle
           @toggle="themeStore.toggleDarkMode"
           :mode="themeStore.isDarkMode ? 'dark' : 'light'"

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,6 @@ import { onMounted, watch } from 'vue';
 import { DARK_GRAY, IVORY } from './constants/colors';
 import useScrollToAnchor from '@/composables/useScrollToAnchor';
 import MorseCodeLoading from '@/components/MorseCodeLoading.vue';
-import EclipseToggle from './components/ui/EclipseToggle.vue';
 
 const store = useAppStore();
 const { networkError, longPolling, notFoundUserError, notFoundSubjectError } = storeToRefs(store);
@@ -83,19 +82,10 @@ console.log(`
       annotation="loading"
     />
 
-    <div
-      id="main"
-      class="flex min-h-screen flex-col paper font-serif text-black dark:text-white"
-    >
+    <div id="main" class="flex min-h-screen flex-col paper font-serif text-black dark:text-white">
       <GlobalHeader />
       <div :class="['bottom-0 container mx-auto w-full p-4 pt-6']">
         <RouterView />
-      </div>
-      <div class="fixed right-6 bottom-6 z-20 hidden sm:flex">
-        <EclipseToggle
-          @toggle="themeStore.toggleDarkMode"
-          :mode="themeStore.isDarkMode ? 'dark' : 'light'"
-        />
       </div>
     </div>
 

--- a/src/components/GlobalHeader.vue
+++ b/src/components/GlobalHeader.vue
@@ -1,50 +1,72 @@
 <script setup>
 import { RouterLink } from 'vue-router';
 import texts from '../constants/texts.js';
+import EclipseToggle from './ui/EclipseToggle.vue';
+import { useThemeStore } from '../stores/theme';
+
+const themeStore = useThemeStore();
 </script>
 
 <template>
-  <header class="min-w-32 paper px-4 pt-0 pb-8 sm:px-6">
-    <nav class="flex items-stretch">
-      <div class="header-links ml-auto flex flex-row flex-wrap items-stretch justify-end gap-0">
-        <!--        <div class="text-gray-400 hover:text-gray-700 dark:hover:text-white">-->
-        <!--          <a href="https://github.com/markni/netabare" about="blank">{{ texts._submitPr }}</a>-->
-        <!--        </div>-->
-        <div
-          v-if="$route.path !== '/'"
-          :class="['header-link', { 'header-link-active': $route.path === '/season' }]"
-        >
-          <RouterLink to="/season">{{ texts._season }}</RouterLink>
+  <header class="min-w-32 paper pt-0 pb-8">
+    <div class="container mx-auto w-full px-0">
+      <nav class="flex items-stretch">
+        <div class="header-links flex w-full flex-row flex-wrap items-stretch justify-start gap-4">
+          <!--        <div class="text-gray-400 hover:text-gray-700 dark:hover:text-white">-->
+          <!--          <a href="https://github.com/markni/netabare" about="blank">{{ texts._submitPr }}</a>-->
+          <!--        </div>-->
+          <div
+            v-if="$route.path !== '/'"
+            :class="['header-link', { 'header-link-active': $route.path === '/season' }]"
+          >
+            <RouterLink class="block px-3 pt-14 pb-2 text-center" to="/season">{{
+              texts._season
+            }}</RouterLink>
+          </div>
+          <div
+            v-if="$route.path !== '/'"
+            :class="['header-link', { 'header-link-active': $route.path === '/trending' }]"
+          >
+            <RouterLink class="block px-3 pt-14 pb-2 text-center" to="/trending">{{
+              texts._trending
+            }}</RouterLink>
+          </div>
+          <div
+            v-if="$route.path !== '/'"
+            :class="['header-link', { 'header-link-active': $route.path === '/history' }]"
+          >
+            <RouterLink class="block px-3 pt-14 pb-2 text-center" to="/history">{{
+              texts._history
+            }}</RouterLink>
+          </div>
+          <div
+            v-if="$route.path !== '/'"
+            :class="['header-link', { 'header-link-active': $route.path === '/user' }]"
+          >
+            <RouterLink class="block px-3 pt-14 pb-2 text-center" to="/user">{{
+              texts._user
+            }}</RouterLink>
+          </div>
+          <div
+            v-if="$route.path !== '/'"
+            :class="[
+              'header-link',
+              { 'header-link-active': $route.path.startsWith('/395378/vs/400602') }
+            ]"
+          >
+            <RouterLink class="block px-3 pt-14 pb-2 text-center" to="/395378/vs/400602">{{
+              texts._experimental
+            }}</RouterLink>
+          </div>
+          <div class="header-toggle ml-auto flex items-end pb-2 pl-3">
+            <EclipseToggle
+              @toggle="themeStore.toggleDarkMode"
+              :mode="themeStore.isDarkMode ? 'dark' : 'light'"
+            />
+          </div>
         </div>
-        <div
-          v-if="$route.path !== '/'"
-          :class="['header-link', { 'header-link-active': $route.path === '/trending' }]"
-        >
-          <RouterLink to="/trending">{{ texts._trending }}</RouterLink>
-        </div>
-        <div
-          v-if="$route.path !== '/'"
-          :class="['header-link', { 'header-link-active': $route.path === '/history' }]"
-        >
-          <RouterLink to="/history">{{ texts._history }}</RouterLink>
-        </div>
-        <div
-          v-if="$route.path !== '/'"
-          :class="['header-link', { 'header-link-active': $route.path === '/user' }]"
-        >
-          <RouterLink to="/user">{{ texts._user }}</RouterLink>
-        </div>
-        <div
-          v-if="$route.path !== '/'"
-          :class="[
-            'header-link',
-            { 'header-link-active': $route.path.startsWith('/395378/vs/400602') }
-          ]"
-        >
-          <RouterLink to="/395378/vs/400602">{{ texts._experimental }}</RouterLink>
-        </div>
-      </div>
-    </nav>
+      </nav>
+    </div>
   </header>
 </template>
 
@@ -64,8 +86,6 @@ import texts from '../constants/texts.js';
 
 .header-link :deep(a) {
   display: block;
-  padding: 3.3rem 0.5rem 0.6rem;
-  text-align: center;
 }
 
 .header-link-active :deep(a) {
@@ -73,12 +93,6 @@ import texts from '../constants/texts.js';
   border-top: none;
   color: #6b7280;
   font-weight: 700;
-}
-
-@media (min-width: 640px) {
-  .header-link {
-    min-width: 7.5rem;
-  }
 }
 
 .dark .header-link {

--- a/src/components/GlobalHeader.vue
+++ b/src/components/GlobalHeader.vue
@@ -4,7 +4,7 @@ import texts from '../constants/texts.js';
 </script>
 
 <template>
-  <header class="min-w-32 paper px-4 pt-0 pb-3 sm:px-6">
+  <header class="min-w-32 paper px-4 pt-0 pb-8 sm:px-6">
     <nav class="flex items-stretch">
       <div class="header-links ml-auto flex flex-row flex-wrap items-stretch justify-end gap-0">
         <!--        <div class="text-gray-400 hover:text-gray-700 dark:hover:text-white">-->

--- a/src/components/GlobalHeader.vue
+++ b/src/components/GlobalHeader.vue
@@ -1,95 +1,99 @@
 <script setup>
 import { RouterLink } from 'vue-router';
 import texts from '../constants/texts.js';
-import { ref } from 'vue';
-import { useThemeStore } from '../stores/theme';
-
-const themeStore = useThemeStore();
-
-const isMenuExpanded = ref(false);
 </script>
 
 <template>
-  <!-- z-49 so it's lower than overlay -->
-  <header
-    class="min-w-32 paper px-8 py-4"
-    :class="{
-      'fixed inset-0 z-40 h-full w-full overflow-y-auto paper sm:relative sm:h-auto sm:w-auto sm:overflow-visible':
-        isMenuExpanded
-    }"
-  >
-    <nav class="flex flex-col items-center sm:items-start">
-      <div
-        class="h-1 w-32 cursor-pointer border-t-4 border-solid border-t-paper-dark pb-4 text-gray-400 hover:text-gray-700 sm:hidden dark:border-t-paper dark:hover:text-white"
-        @click="isMenuExpanded = !isMenuExpanded"
-      ></div>
-      <div
-        class="flex flex-col gap-4 overflow-hidden sm:h-auto"
-        :class="{ 'h-auto': isMenuExpanded, 'h-0': !isMenuExpanded }"
-      >
-        <div
-          v-if="$route.path !== '/'"
-          class="text-gray-400 hover:text-gray-700 dark:hover:text-white"
-        >
-          <RouterLink to="/">{{ texts._backToHome }}</RouterLink>
-        </div>
-        <div class="text-gray-400 hover:text-gray-700 dark:hover:text-white">
-          <a href="https://bgm.tv/group/topic/346147" about="blank">{{ texts._feedback }}</a>
-        </div>
-        <div class="text-gray-400 hover:text-gray-700 dark:hover:text-white">
-          <a href="https://bgm.tv/group/topic/346147" about="blank">{{ texts._changeLog }}</a>
-        </div>
+  <header class="min-w-32 paper px-4 pt-0 pb-3 sm:px-6">
+    <nav class="flex items-stretch">
+      <div class="header-links ml-auto flex flex-row flex-wrap items-stretch justify-end gap-0">
         <!--        <div class="text-gray-400 hover:text-gray-700 dark:hover:text-white">-->
         <!--          <a href="https://github.com/markni/netabare" about="blank">{{ texts._submitPr }}</a>-->
         <!--        </div>-->
-        <div class="mt-4">
-          <!-- gap between main links and other links -->
-        </div>
         <div
           v-if="$route.path !== '/'"
-          class="text-gray-400 hover:text-gray-700 dark:hover:text-white"
+          :class="['header-link', { 'header-link-active': $route.path === '/season' }]"
         >
           <RouterLink to="/season">{{ texts._season }}</RouterLink>
         </div>
         <div
           v-if="$route.path !== '/'"
-          class="text-gray-400 hover:text-gray-700 dark:hover:text-white"
+          :class="['header-link', { 'header-link-active': $route.path === '/trending' }]"
         >
           <RouterLink to="/trending">{{ texts._trending }}</RouterLink>
         </div>
         <div
           v-if="$route.path !== '/'"
-          class="text-gray-400 hover:text-gray-700 dark:hover:text-white"
+          :class="['header-link', { 'header-link-active': $route.path === '/history' }]"
         >
           <RouterLink to="/history">{{ texts._history }}</RouterLink>
         </div>
         <div
           v-if="$route.path !== '/'"
-          class="text-gray-400 hover:text-gray-700 dark:hover:text-white"
+          :class="['header-link', { 'header-link-active': $route.path === '/user' }]"
         >
           <RouterLink to="/user">{{ texts._user }}</RouterLink>
         </div>
         <div
           v-if="$route.path !== '/'"
-          class="text-gray-400 hover:text-gray-700 dark:hover:text-white"
+          :class="[
+            'header-link',
+            { 'header-link-active': $route.path.startsWith('/395378/vs/400602') }
+          ]"
         >
           <RouterLink to="/395378/vs/400602">{{ texts._experimental }}</RouterLink>
-        </div>
-
-        <div class="mt-4">
-          <!-- gap between main links and other links -->
-        </div>
-
-        <div
-          class="flex cursor-pointer text-gray-400 hover:text-gray-700 sm:hidden dark:hover:text-white"
-        >
-          <a @click="themeStore.toggleDarkMode">{{
-            themeStore.isDarkMode ? texts._lightMode : texts._darkMode
-          }}</a>
         </div>
       </div>
     </nav>
   </header>
 </template>
 
-<style scoped></style>
+<style scoped>
+.header-links {
+  border: none;
+}
+
+.header-link {
+  border: none;
+  color: #111827;
+  font-family: 'Noto Serif SC', 'Source Han Serif SC', 'Songti SC', serif;
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.header-link :deep(a) {
+  display: block;
+  padding: 3.3rem 0.5rem 0.6rem;
+  text-align: center;
+}
+
+.header-link-active :deep(a) {
+  border: 1px solid #c9c9c9;
+  border-top: none;
+  color: #6b7280;
+  font-weight: 700;
+}
+
+@media (min-width: 640px) {
+  .header-link {
+    min-width: 7.5rem;
+  }
+}
+
+.dark .header-link {
+  border: none;
+  color: #d1d5db;
+}
+
+.dark .header-links {
+  border: none;
+}
+
+.dark .header-link-active :deep(a) {
+  border: 1px solid #6b7280;
+  border-top: none;
+  color: #f3f4f6;
+  font-weight: 700;
+}
+</style>


### PR DESCRIPTION
## Summary
- move global navigation to a consistent top-header layout on all screen sizes
- simplify header by removing mobile expand/collapse logic
- restyle nav items to match reference look and feel (active vs non-active treatment, spacing, weight, alignment)
- hide 返回首页 / 问题反馈 / 更新日志 and right-align remaining nav items

## Verification
- npm run build