### PR TITLE
Refactor header nav styling and semantic theme tokens

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -82,7 +82,10 @@ console.log(`
       annotation="loading"
     />
 
-    <div id="main" class="flex min-h-screen flex-col paper font-serif text-black dark:text-white">
+    <div
+      id="main"
+      class="flex min-h-screen flex-col bg-background font-serif text-black transition-[background-color] duration-300 dark:text-white"
+    >
       <GlobalHeader />
       <div :class="['bottom-0 container mx-auto w-full p-4 pt-6']">
         <RouterView />

--- a/src/components/GlobalHeader.vue
+++ b/src/components/GlobalHeader.vue
@@ -8,84 +8,76 @@ const themeStore = useThemeStore();
 </script>
 
 <template>
-  <header class="min-w-32 paper pt-0 pb-8">
+  <header class="min-w-32 bg-background pt-0 pb-8 transition-[background-color] duration-300">
     <div class="container mx-auto w-full px-4">
       <nav class="flex items-stretch">
-        <div class="header-links flex w-full flex-row flex-wrap items-stretch justify-start gap-4">
-          <!--        <div class="text-gray-400 hover:text-gray-700 dark:hover:text-white">-->
-          <!--          <a href="https://github.com/markni/netabare" about="blank">{{ texts._submitPr }}</a>-->
-          <!--        </div>-->
+        <div class="flex w-full flex-row flex-wrap items-stretch justify-start gap-4">
           <div
-            v-if="$route.path !== '/'"
             :class="[
-              'header-link',
-              'mx-1 sm:mx-0',
-              { 'header-link-active': $route.path === '/season' }
+              'mx-1 border-0 text-[0.95rem] leading-[1.2] font-bold text-foreground sm:mx-0',
+              { invisible: $route.path === '/', 'pointer-events-none': $route.path === '/' }
             ]"
           >
             <RouterLink
-              class="block px-3 pt-14 pb-2 text-center vertical-rl sm:horizontal-tb"
+              active-class="!border !border-foreground !border-t-0 !text-muted-foreground"
+              class="block border border-t-0 border-transparent px-3 pt-14 pb-2 text-center vertical-rl sm:horizontal-tb"
               to="/season"
               >{{ texts._season }}</RouterLink
             >
           </div>
           <div
-            v-if="$route.path !== '/'"
             :class="[
-              'header-link',
-              'mx-1 sm:mx-0',
-              { 'header-link-active': $route.path === '/trending' }
+              'mx-1 border-0 text-[0.95rem] leading-[1.2] font-bold text-foreground sm:mx-0',
+              { invisible: $route.path === '/', 'pointer-events-none': $route.path === '/' }
             ]"
           >
             <RouterLink
-              class="block px-3 pt-14 pb-2 text-center vertical-rl sm:horizontal-tb"
+              active-class="!border !border-foreground !border-t-0 !text-muted-foreground"
+              class="block border border-t-0 border-transparent px-3 pt-14 pb-2 text-center vertical-rl sm:horizontal-tb"
               to="/trending"
               >{{ texts._trending }}</RouterLink
             >
           </div>
           <div
-            v-if="$route.path !== '/'"
             :class="[
-              'header-link',
-              'mx-1 sm:mx-0',
-              { 'header-link-active': $route.path === '/history' }
+              'mx-1 border-0 text-[0.95rem] leading-[1.2] font-bold text-foreground sm:mx-0',
+              { invisible: $route.path === '/', 'pointer-events-none': $route.path === '/' }
             ]"
           >
             <RouterLink
-              class="block px-3 pt-14 pb-2 text-center vertical-rl sm:horizontal-tb"
+              active-class="!border !border-foreground !border-t-0 !text-muted-foreground"
+              class="block border border-t-0 border-transparent px-3 pt-14 pb-2 text-center vertical-rl sm:horizontal-tb"
               to="/history"
               >{{ texts._history }}</RouterLink
             >
           </div>
           <div
-            v-if="$route.path !== '/'"
             :class="[
-              'header-link',
-              'mx-1 sm:mx-0',
-              { 'header-link-active': $route.path === '/user' }
+              'mx-1 border-0 text-[0.95rem] leading-[1.2] font-bold text-foreground sm:mx-0',
+              { invisible: $route.path === '/', 'pointer-events-none': $route.path === '/' }
             ]"
           >
             <RouterLink
-              class="block px-3 pt-14 pb-2 text-center vertical-rl sm:horizontal-tb"
+              active-class="!border !border-foreground !border-t-0 !text-muted-foreground"
+              class="block border border-t-0 border-transparent px-3 pt-14 pb-2 text-center vertical-rl sm:horizontal-tb"
               to="/user"
               >{{ texts._user }}</RouterLink
             >
           </div>
           <div
-            v-if="$route.path !== '/'"
             :class="[
-              'header-link',
-              'mx-1 sm:mx-0',
-              { 'header-link-active': $route.path.startsWith('/395378/vs/400602') }
+              'mx-1 border-0 text-[0.95rem] leading-[1.2] font-bold text-foreground sm:mx-0',
+              { invisible: $route.path === '/', 'pointer-events-none': $route.path === '/' }
             ]"
           >
             <RouterLink
-              class="block px-3 pt-14 pb-2 text-center vertical-rl sm:horizontal-tb"
+              active-class="!border !border-foreground !border-t-0 !text-muted-foreground"
+              class="block border border-t-0 border-transparent px-3 pt-14 pb-2 text-center vertical-rl sm:horizontal-tb"
               to="/395378/vs/400602"
               >{{ texts._experimental }}</RouterLink
             >
           </div>
-          <div class="header-toggle ml-auto flex items-end pb-2 pl-3">
+          <div class="ml-auto flex items-end pb-2 pl-3">
             <EclipseToggle
               @toggle="themeStore.toggleDarkMode"
               :mode="themeStore.isDarkMode ? 'dark' : 'light'"
@@ -96,45 +88,3 @@ const themeStore = useThemeStore();
     </div>
   </header>
 </template>
-
-<style scoped>
-.header-links {
-  border: none;
-}
-
-.header-link {
-  border: none;
-  color: #111827;
-  font-family: 'Noto Serif SC', 'Source Han Serif SC', 'Songti SC', serif;
-  font-size: 0.95rem;
-  font-weight: 700;
-  line-height: 1.2;
-}
-
-.header-link :deep(a) {
-  display: block;
-}
-
-.header-link-active :deep(a) {
-  border: 1px solid #c9c9c9;
-  border-top: none;
-  color: #6b7280;
-  font-weight: 700;
-}
-
-.dark .header-link {
-  border: none;
-  color: #d1d5db;
-}
-
-.dark .header-links {
-  border: none;
-}
-
-.dark .header-link-active :deep(a) {
-  border: 1px solid #6b7280;
-  border-top: none;
-  color: #f3f4f6;
-  font-weight: 700;
-}
-</style>

--- a/src/components/YearSlider.vue
+++ b/src/components/YearSlider.vue
@@ -5,16 +5,16 @@
     </div>
     <div
       v-else
-      class="range relative table h-[140px] w-[140px] rounded-full paper"
+      class="range relative table h-[140px] w-[140px] rounded-full bg-background transition-[background-color] duration-300"
       ref="range"
       @mousedown.prevent="rangeSliderInit"
       @touchstart.prevent="rangeSliderInit"
     >
       <div class="slice left opacity-15" :style="{ backgroundColor: progressColor }">
-        <div class="blocker paper"></div>
+        <div class="blocker bg-background transition-[background-color] duration-300"></div>
       </div>
       <div class="slice right opacity-15" :style="{ backgroundColor: progressColor }">
-        <div class="blocker paper"></div>
+        <div class="blocker bg-background transition-[background-color] duration-300"></div>
       </div>
 
       <span class="info flex items-center justify-center">

--- a/src/index.css
+++ b/src/index.css
@@ -6,8 +6,6 @@
 @theme {
   --color-red: var(--color-red-900);
   --color-ivory: var(--color-stone-50);
-  --color-dark-gray: var(--color-neutral-900);
-  --color-light-gray: var(--color-neutral-500);
 
   --color-teal: #89cebe;
   --color-gold: #e4ae4a;
@@ -16,12 +14,12 @@
 
   /* transparent, black and white are predefined in Tailwind */
 
-  --color-paper: light-dark(#fafaf9, #171717);
-  /* backward compatibility classes, use dark:bg-paper-dark*/
-  --color-paper-dark: #171717;
-
-  --color-active-link: light-dark(var(--color-dark-gray), var(--color-white));
-  --color-active-link-dark: var(--color-white);
+  --color-background: light-dark(#fafaf9, #171717);
+  --color-foreground: light-dark(var(--color-neutral-900), var(--color-white));
+  --color-muted: light-dark(var(--color-stone-50), var(--color-neutral-800));
+  --color-muted-foreground: light-dark(var(--color-neutral-500), var(--color-neutral-300));
+  --color-border: light-dark(var(--color-neutral-500), var(--color-neutral-500));
+  --color-ring: light-dark(var(--color-neutral-900), var(--color-white));
 
   --font-sans: 'Inter', sans-serif;
   --font-serif: 'source-han-serif-sc', 'source-han-serif-japanese', '宋体', '新宋体', serif;
@@ -39,10 +37,6 @@
   writing-mode: vertical-lr;
 }
 
-@utility paper {
-  @apply bg-paper transition-[background-color] duration-300 dark:bg-paper-dark;
-}
-
 :root {
   color-scheme: only light;
 }
@@ -53,6 +47,8 @@
 
 html {
   scroll-behavior: smooth;
+  /* Keep layout width stable when vertical scrollbar appears/disappears */
+  scrollbar-gutter: stable;
 }
 
 #app {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,8 +4,8 @@ import { useAppStore } from '@/stores/app';
 import texts from '@/constants/texts.js';
 
 const router = createRouter({
-  linkActiveClass: 'text-active-link dark:text-active-link-dark',
-  linkExactActiveClass: 'text-active-link dark:text-active-link-dark',
+  linkActiveClass: 'text-foreground',
+  linkExactActiveClass: 'text-foreground',
   scrollBehavior(to, from, savedPosition) {
     if (savedPosition) {
       return savedPosition;

--- a/src/views/DebugThemeToggleView.vue
+++ b/src/views/DebugThemeToggleView.vue
@@ -2,7 +2,7 @@
   <div class="mx-auto flex w-full max-w-7xl flex-col gap-8 px-4 sm:px-8">
     <section class="flex flex-col gap-2">
       <h1 class="text-3xl font-semibold">Theme Toggle Debug</h1>
-      <p class="text-light-gray dark:text-gray-400">
+      <p class="text-muted-foreground">
         Compare legacy <code>ThemeToggle</code> and new <code>EclipseToggle</code> against the same
         theme state.
       </p>
@@ -31,21 +31,21 @@
       <div class="my-[40rem] px-8 sm:px-16">
         <div class="grid gap-x-24 gap-y-[40rem] sm:grid-cols-3">
           <div class="flex flex-col items-center gap-2">
-            <span class="min-h-10 text-center text-sm text-light-gray dark:text-gray-400">
+            <span class="min-h-10 text-center text-sm text-muted-foreground">
               Locked dark<br />
               (closed)
             </span>
             <ThemeToggle v-bind="normalizedLegacyShadow" mode="dark" :interactive="false" />
           </div>
           <div class="flex flex-col items-center gap-2">
-            <span class="min-h-10 text-center text-sm text-light-gray dark:text-gray-400">
+            <span class="min-h-10 text-center text-sm text-muted-foreground">
               Locked light<br />
               (open)
             </span>
             <ThemeToggle v-bind="normalizedLegacyShadow" mode="light" :interactive="false" />
           </div>
           <div class="flex flex-col items-center gap-2">
-            <span class="min-h-10 text-center text-sm text-light-gray dark:text-gray-400">
+            <span class="min-h-10 text-center text-sm text-muted-foreground">
               Interactive<br />
               (normal)
             </span>
@@ -112,15 +112,13 @@
         <label class="flex flex-col gap-1 text-sm">
           <span>shadowFade: {{ legacyShadow.shadowFade.toFixed(1) }}</span>
           <input v-model.number="legacyShadow.shadowFade" type="range" min="0" max="8" step="0.1" />
-          <span class="text-xs text-light-gray dark:text-gray-400">
-            Higher = fades out faster from center
-          </span>
+          <span class="text-xs text-muted-foreground"> Higher = fades out faster from center </span>
         </label>
 
         <label class="flex flex-col gap-1 text-sm">
           <span>blur: {{ legacyShadow.blur.toFixed(2) }}</span>
           <input v-model.number="legacyShadow.blur" type="range" min="0" max="10" step="0.01" />
-          <span class="text-xs text-light-gray dark:text-gray-400">
+          <span class="text-xs text-muted-foreground">
             Constant blur amount applied to every layer
           </span>
         </label>
@@ -134,7 +132,7 @@
             max="5"
             step="0.01"
           />
-          <span class="text-xs text-light-gray dark:text-gray-400">
+          <span class="text-xs text-muted-foreground">
             Extra blur added per layer offset distance
           </span>
         </label>
@@ -186,7 +184,7 @@
           @toggle="themeStore.toggleDarkMode"
           :mode="themeStore.isDarkMode ? 'dark' : 'light'"
         />
-        <span class="text-sm text-light-gray dark:text-gray-400">
+        <span class="text-sm text-muted-foreground">
           mode: {{ themeStore.isDarkMode ? 'dark' : 'light' }}
         </span>
       </div>

--- a/src/views/GuessView.vue
+++ b/src/views/GuessView.vue
@@ -7,10 +7,10 @@
 
     <div class="flex flex-col justify-between gap-16 sm:flex-row">
       <h1 class="text-2xl sm:text-4xl">{{ texts._scoreChartRecognition }}</h1>
-      <div class="border-b-paper-dark dark:border-paper relative w-64 border-b">
+      <div class="relative w-64 border-b border-b-border">
         <div
           v-if="guessStore.score !== null"
-          class="text-red absolute bottom-[-30px] left-16 z-30 text-8xl underline underline-offset-8"
+          class="absolute bottom-[-30px] left-16 z-30 text-8xl text-red underline underline-offset-8"
           style="transform: rotate(-5deg)"
         >
           {{ JSON.stringify(guessStore.score * 10) }}
@@ -39,7 +39,7 @@
           :key="aIndex"
           @click="selectAnswer(qIndex, aIndex)"
           :class="[
-            'hover:border-blue relative cursor-pointer rounded-lg border-2 p-3 transition-all duration-200',
+            'relative cursor-pointer rounded-lg border-2 p-3 transition-all duration-200 hover:border-blue',
             guessStore.answers[qIndex] === aIndex ? 'border-blue' : 'border-gray-200'
           ]"
         >
@@ -47,7 +47,7 @@
 
           <div
             v-if="guessStore.answers[qIndex] === aIndex && guessStore.score !== null"
-            class="text-red absolute z-30 text-8xl"
+            class="absolute z-30 text-8xl text-red"
             :style="{
               transform: `rotate(${-5 + Math.random() * 10 - 5}deg)`,
               top: `${-20 + Math.random() * 10 - 5}px`,
@@ -67,7 +67,7 @@
       :class="[
         'w-full rounded-lg py-3.5 text-2xl transition-colors',
         isComplete || guessStore.score !== null
-          ? 'bg-blue hover:bg-blue cursor-pointer text-white'
+          ? 'cursor-pointer bg-blue text-white hover:bg-blue'
           : 'cursor-not-allowed bg-gray-400 text-white'
       ]"
     >

--- a/src/views/HistoryView.vue
+++ b/src/views/HistoryView.vue
@@ -118,7 +118,12 @@ watch(
     <div class="flex flex-col">
       <label for="startingYear" class="text-xl">{{ texts._startingYear }}</label>
       <select class="w-40 bg-transparent" id="startingYear" v-model="startingYear">
-        <option class="paper" v-for="year in validStartYears" :key="year" :value="year">
+        <option
+          class="bg-background transition-[background-color] duration-300"
+          v-for="year in validStartYears"
+          :key="year"
+          :value="year"
+        >
           {{ year }}
         </option>
       </select>
@@ -126,7 +131,12 @@ watch(
     <div class="flex flex-col">
       <label for="endingYear" class="text-xl">{{ texts._endingYear }}</label>
       <select class="w-40 bg-transparent" id="endingYear" v-model="endingYear">
-        <option class="paper" v-for="year in validEndYears" :key="year" :value="year">
+        <option
+          class="bg-background transition-[background-color] duration-300"
+          v-for="year in validEndYears"
+          :key="year"
+          :value="year"
+        >
           {{ year }}
         </option>
       </select>
@@ -134,7 +144,12 @@ watch(
     <div class="flex flex-col">
       <label for="minScore" class="text-xl">{{ texts._minScore }}</label>
       <select class="w-40 bg-transparent" id="minScore" v-model="minScore">
-        <option class="paper" v-for="score in validMinScores" :key="score" :value="score">
+        <option
+          class="bg-background transition-[background-color] duration-300"
+          v-for="score in validMinScores"
+          :key="score"
+          :value="score"
+        >
           {{ score }}
         </option>
       </select>
@@ -142,7 +157,12 @@ watch(
     <div class="flex flex-col">
       <label for="maxScore" class="text-xl">{{ texts._maxScore }}</label>
       <select class="w-40 bg-transparent" id="maxScore" v-model="maxScore">
-        <option class="paper" v-for="score in validMaxScores" :key="score" :value="score">
+        <option
+          class="bg-background transition-[background-color] duration-300"
+          v-for="score in validMaxScores"
+          :key="score"
+          :value="score"
+        >
           {{ score }}
         </option>
       </select>

--- a/src/views/SeasonView.vue
+++ b/src/views/SeasonView.vue
@@ -125,7 +125,7 @@ const handleSeasonChange = (event) => {
         @change="handleYearChange"
         aria-label="选择年份"
       >
-        <option v-for="year in years" :key="year" :value="year" class="bg-paper dark:bg-paper-dark">
+        <option v-for="year in years" :key="year" :value="year" class="bg-background">
           {{ year }}
         </option>
       </select>
@@ -139,7 +139,7 @@ const handleSeasonChange = (event) => {
           v-for="season in availableSeasons"
           :key="season.month"
           :value="season.month"
-          class="paper"
+          class="bg-background transition-[background-color] duration-300"
         >
           {{ season.name }}
         </option>

--- a/src/views/SubjectView.vue
+++ b/src/views/SubjectView.vue
@@ -94,7 +94,9 @@ const setRatingPeriod = (period) => {
           >{{ decodedName }}</a
         >
       </h1>
-      <div class="sticky top-0 z-[48] flex w-full flex-col items-end gap-4 paper py-5">
+      <div
+        class="sticky top-0 z-[48] flex w-full flex-col items-end gap-4 bg-background py-5 transition-[background-color] duration-300"
+      >
         <h2 class="text-4xl" v-if="subject.name_cn">
           <a
             class="hover:bg-gold"

--- a/src/views/TrendingView.vue
+++ b/src/views/TrendingView.vue
@@ -18,7 +18,9 @@ const formatData = (history) =>
 <template>
   <div class="xl: grid grid-cols-1 gap-32 px-4 pt-14 xl:grid-cols-3" v-if="done.length">
     <div v-for="(items, index) in [done, up, down]" :key="index" class="flex flex-col gap-16">
-      <div class="sticky top-0 z-10 flex w-full paper py-4">
+      <div
+        class="sticky top-0 z-10 flex w-full bg-background py-4 transition-[background-color] duration-300"
+      >
         <h2
           :id="['popular', 'up', 'down'][index]"
           class="mr-auto text-2xl tracking-wider first-letter:text-3xl"

--- a/src/views/VsView.vue
+++ b/src/views/VsView.vue
@@ -75,7 +75,9 @@ const { getRatingData } = store;
       />
     </div>
     <div v-if="props.id0 !== props.id1" class="flex flex-col gap-20">
-      <div class="sticky top-0 z-10 grid grid-cols-2 gap-4 paper py-4 text-3xl">
+      <div
+        class="sticky top-0 z-10 grid grid-cols-2 gap-4 bg-background py-4 text-3xl transition-[background-color] duration-300"
+      >
         <form @submit.prevent="submit" class="flex flex-col gap-4 text-blue">
           <!-- <input type="number" class="w-40 bg-transparent" id="localId0" v-model="localId0" /> -->
           <div class="text-6xl">


### PR DESCRIPTION
## Summary
- migrate theme aliases to semantic tokens (ackground, oreground, muted-foreground, order, ing)
- replace old paper/text color usages with semantic Tailwind classes across affected views
- simplify GlobalHeader to inline Tailwind classes and remove header-specific scoped CSS
- fix active nav border behavior using RouterLink ctive-class with non-active transparent borders that preserve layout

## Validation
- npm run build