### PR TITLE
Add 7-day Dependabot cooldown for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       npm-dependencies:
         patterns:


### PR DESCRIPTION
## Summary
- add Dependabot cooldown configuration for npm version updates
- set default-days: 7 to wait at least one week before update PRs

## Notes
- this applies to version updates, not security updates