### PR TITLE
Refine layout container width and season bleed utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Agent Instructions
+
+## Pull Requests
+- Use clear Markdown in PR descriptions.
+- Use this minimal structure:
+  - `## Summary`
+  - `## Notes`
+- Verify the rendered PR body after creating or editing the PR.

--- a/src/App.vue
+++ b/src/App.vue
@@ -87,11 +87,11 @@ console.log(`
       class="flex min-h-screen flex-col bg-background font-serif text-black transition-[background-color] duration-300 dark:text-white"
     >
       <GlobalHeader />
-      <div :class="['bottom-0 container mx-auto w-full p-4 pt-6']">
+      <div :class="['bottom-0 mx-auto w-full max-w-6xl p-4 pt-6']">
         <RouterView />
       </div>
       <footer class="mt-auto bg-black text-white dark:bg-white dark:text-black">
-        <div class="container mx-auto w-full px-4 py-3">
+        <div class="mx-auto w-full max-w-6xl px-4 py-3">
           <div class="flex flex-wrap items-center gap-4 text-sm">
             <RouterLink to="/">{{ texts._backToHome }}</RouterLink>
             <a href="https://bgm.tv/group/topic/346147" target="_blank" rel="noopener noreferrer">{{

--- a/src/components/FullscreenOverlay.vue
+++ b/src/components/FullscreenOverlay.vue
@@ -22,7 +22,7 @@ defineProps({
 
 <template>
   <div :class="'fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 ' + color">
-    <p class="float text-center text-6xl tracking-[30px] text-white vertical-rl">
+    <p class="float text-center text-6xl font-bold tracking-[30px] text-white vertical-rl">
       {{ text }}
     </p>
     <div class="flex flex-col gap-2">
@@ -50,3 +50,4 @@ defineProps({
   animation: float 6s ease-in-out infinite;
 }
 </style>
+

--- a/src/components/GlobalHeader.vue
+++ b/src/components/GlobalHeader.vue
@@ -9,7 +9,7 @@ const themeStore = useThemeStore();
 
 <template>
   <header class="min-w-32 bg-background pt-0 pb-8 transition-[background-color] duration-300">
-    <div class="container mx-auto w-full px-4">
+    <div class="mx-auto w-full max-w-6xl px-4">
       <nav class="flex items-stretch">
         <div class="flex w-full flex-row flex-wrap items-stretch justify-start gap-4">
           <div

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,14 @@
   writing-mode: vertical-lr;
 }
 
+@utility bleed-left-to-container-right {
+  margin-left: calc((100dvw - 100cqw) / -2);
+}
+
+@utility bleed-right-to-container-left {
+  margin-right: calc((100dvw - 100cqw) / -2);
+}
+
 :root {
   color-scheme: only light;
 }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="containerRef"
-    class="flex h-full w-full flex-col items-center justify-center gap-64 text-6xl tracking-wider"
+    class="flex h-full w-full flex-col items-center justify-center gap-64 tracking-wider"
   >
     <!-- Auto-scroll indicator (only show when active) -->
     <div
@@ -439,3 +439,4 @@ onUnmounted(() => {
   }
 }
 </style>
+

--- a/src/views/SeasonView.vue
+++ b/src/views/SeasonView.vue
@@ -117,34 +117,38 @@ const handleSeasonChange = (event) => {
 </script>
 
 <template>
-  <div class="mt-14 flex flex-col gap-10">
-    <div class="flex items-baseline">
-      <select
-        class="mr-2 bg-transparent text-4xl sm:text-6xl"
-        :value="route.params.year || new Date().getFullYear()"
-        @change="handleYearChange"
-        aria-label="选择年份"
-      >
-        <option v-for="year in years" :key="year" :value="year" class="bg-background">
-          {{ year }}
-        </option>
-      </select>
-      <select
-        class="mr-2 bg-transparent text-4xl sm:text-6xl"
-        :value="parseInt(route.params.month) || getCurrentSeason(new Date().getMonth() + 1)"
-        @change="handleSeasonChange"
-        aria-label="选择季度"
-      >
-        <option
-          v-for="season in availableSeasons"
-          :key="season.month"
-          :value="season.month"
-          class="bg-background transition-[background-color] duration-300"
+  <div class="@container mt-14 flex flex-col gap-10">
+    <div class="flex flex-col gap-2">
+      <div class="flex items-baseline">
+        <select
+          class="mr-2 bg-transparent text-4xl sm:text-6xl sm:font-bold"
+          :value="route.params.year || new Date().getFullYear()"
+          @change="handleYearChange"
+          aria-label="选择年份"
         >
-          {{ season.name }}
-        </option>
-      </select>
-      <h1 class="text-4xl sm:text-6xl">{{ texts._seasonBattleStatus }}</h1>
+          <option v-for="year in years" :key="year" :value="year" class="bg-background">
+            {{ year }}
+          </option>
+        </select>
+        <select
+          class="mr-2 bg-transparent text-4xl sm:text-6xl sm:font-bold"
+          :value="parseInt(route.params.month) || getCurrentSeason(new Date().getMonth() + 1)"
+          @change="handleSeasonChange"
+          aria-label="选择季度"
+        >
+          <option
+            v-for="season in availableSeasons"
+            :key="season.month"
+            :value="season.month"
+            class="bg-background transition-[background-color] duration-300"
+          >
+            {{ season.name }}
+          </option>
+        </select>
+        <h1 class="text-4xl sm:text-6xl sm:font-bold">{{ texts._seasonBattleStatus }}</h1>
+      </div>
+
+      <h2 class="text-3xl font-bold">该季度最热门的作品对比</h2>
     </div>
 
     <div class="flex flex-col gap-4">
@@ -154,14 +158,14 @@ const handleSeasonChange = (event) => {
       <HintDiv :title="texts._altKeyShowLabels"> {{ texts._howToShowLabels }} </HintDiv>
       <h2 class="text-2xl">{{ texts._top10ScoreComparison }}</h2>
 
-      <div class="sm:aspect-[16/10]">
+      <div class="bleed-left-to-container-right sm:aspect-[16/10]">
         <BattleChart :historyData="historyData" :showLabels="showLabels" />
       </div>
     </div>
 
     <div class="flex flex-col gap-4">
       <h2 class="text-2xl">{{ texts._top10RankingComparison }}</h2>
-      <div class="sm:aspect-[16/10]">
+      <div class="bleed-right-to-container-left sm:aspect-[16/10]">
         <BattleRankChart :historyData="historyData" :showLabels="showLabels" />
       </div>
     </div>
@@ -169,7 +173,7 @@ const handleSeasonChange = (event) => {
     <div class="flex flex-col gap-4">
       <h2 class="text-2xl">{{ texts._balanceChart }}</h2>
       <p class="text-gray-400">{{ texts._scoreComparison }}</p>
-      <div class="sm:aspect-[10/5]">
+      <div class="bleed-left-to-container-right sm:aspect-[10/5]">
         <BattleBarChart :balanceData="balanceData" />
       </div>
     </div>
@@ -179,7 +183,7 @@ const handleSeasonChange = (event) => {
       <p class="cursor-help text-gray-400" :title="texts._chartLegend">
         {{ texts._chartLegend }}
       </p>
-      <div class="sm:aspect-[10/5]">
+      <div class="bleed-right-to-container-left sm:aspect-[10/5]">
         <ScoreBubbleChart :subjects="subjectsData" />
       </div>
     </div>

--- a/src/views/SubjectView.vue
+++ b/src/views/SubjectView.vue
@@ -85,7 +85,7 @@ const setRatingPeriod = (period) => {
 <template>
   <div v-if="subject">
     <div class="flex flex-col items-end gap-4">
-      <h1 class="pt-8 text-6xl">
+      <h1 class="pt-8 text-6xl font-bold">
         <a
           class="hover:bg-gold"
           target="_blank"
@@ -288,3 +288,4 @@ const setRatingPeriod = (period) => {
 </template>
 
 <style scoped></style>
+

--- a/src/views/UIView.vue
+++ b/src/views/UIView.vue
@@ -45,7 +45,7 @@
         <div class="text-3xl">動畫番號 貳拾壹</div>
         <div class="text-4xl">動畫番號 貳拾壹</div>
         <div class="text-5xl">動畫番號 貳拾壹</div>
-        <div class="text-6xl">動畫番號 貳拾壹</div>
+        <div class="text-6xl font-bold">動畫番號 貳拾壹</div>
       </div>
     </section>
 
@@ -124,3 +124,4 @@ function testFullscreenOverlay() {
   }, 5000);
 }
 </script>
+

--- a/src/views/VsView.vue
+++ b/src/views/VsView.vue
@@ -66,7 +66,7 @@ const { getRatingData } = store;
 
 <template>
   <div class="pt-14">
-    <div v-if="props.id0 === props.id1" class="text-6xl">
+    <div v-if="props.id0 === props.id1" class="text-6xl font-bold">
       <FullscreenOverlay
         :text="texts._destroyedSpaceTime"
         :annotation="texts._gameOver"
@@ -80,7 +80,7 @@ const { getRatingData } = store;
       >
         <form @submit.prevent="submit" class="flex flex-col gap-4 text-blue">
           <!-- <input type="number" class="w-40 bg-transparent" id="localId0" v-model="localId0" /> -->
-          <div class="text-6xl">
+          <div class="text-6xl font-bold">
             {{ subjects[0]?.rating?.score || 'N/A' }}
           </div>
           <label for="localId0" class="text-xl">{{
@@ -89,7 +89,7 @@ const { getRatingData } = store;
         </form>
         <form @submit.prevent="submit" class="al flex flex-col items-end gap-4 text-pink">
           <!-- <input type="number" class="w-40 bg-transparent" id="localId1" v-model="localId1" /> -->
-          <div class="text-6xl">
+          <div class="text-6xl font-bold">
             {{ subjects[1]?.rating?.score || 'N/A' }}
           </div>
           <label for="localId1" class="text-xl">
@@ -141,3 +141,4 @@ const { getRatingData } = store;
 </template>
 
 <style scoped></style>
+


### PR DESCRIPTION
## Summary
- Switch app/header/footer wrappers from Tailwind `container` to `max-w-6xl` for a narrower global layout.
- Add reusable bleed utilities based on container query units (`cqw`).
- Apply alternating left/right bleed wrappers to season charts.
- Make all `text-6xl` usages bold while preserving responsive intent.

## Notes
- Keeps `@container` in `SeasonView` for bleed calculations.
- Leaves `FoilCard` local `.container` styling unchanged.