### PR TITLE
Improve season score/rank legend ordering and prefixes

### DIFF
--- a/src/components/charts/BattleChart.vue
+++ b/src/components/charts/BattleChart.vue
@@ -21,18 +21,42 @@ const chartInstance = shallowRef(null);
 const router = useRouter();
 useChartTheme(chartInstance);
 
+const getLatestScore = (scoreHistory = []) => {
+  if (!Array.isArray(scoreHistory) || scoreHistory.length === 0) return Number.NEGATIVE_INFINITY;
+  const latest = Number(scoreHistory[scoreHistory.length - 1]?.[1]);
+  return Number.isFinite(latest) ? latest : Number.NEGATIVE_INFINITY;
+};
+
 const updateData = () => {
   if (chartInstance.value) {
     const currentSeries = {};
 
-    // Create a map of existing series by their names for easy lookup
+    // Create a map of existing series by their id for reliable updates
     chartInstance.value.series.forEach((series) => {
-      currentSeries[series.name] = series;
+      const seriesId = String(series.userOptions?.id || '');
+      if (seriesId) {
+        currentSeries[seriesId] = series;
+      }
+    });
+
+    // Keep sorting local to this chart: do not mutate source data from the store.
+    const sortedHistoryData = [...props.historyData].sort((a, b) => {
+      const scoreDiff = getLatestScore(b.scoreHistory) - getLatestScore(a.scoreHistory);
+      if (scoreDiff !== 0) return scoreDiff;
+      const nameA = a?.name || '';
+      const nameB = b?.name || '';
+      return nameA.localeCompare(nameB, 'zh-Hans-CN');
     });
 
     // Add or update series
-    props.historyData.forEach((seriesData) => {
+    sortedHistoryData.forEach((seriesData) => {
       const { name, bgmId, scoreHistory, color, airDate } = seriesData;
+      const latestScore =
+        Array.isArray(scoreHistory) && scoreHistory.length > 0
+          ? Number(scoreHistory[scoreHistory.length - 1][1])
+          : null;
+      const scorePrefix = Number.isFinite(latestScore) ? latestScore.toFixed(2) : 'N/A';
+      const legendName = `${scorePrefix} ${name}`;
       const zones = [
         {
           value: airDate, // All points with x < airDate
@@ -59,7 +83,7 @@ const updateData = () => {
           y: formattedData[lastIndex][1],
           dataLabels: {
             enabled: true,
-            format: `${name}: {y:.2f}`,
+            format: `${legendName}: {y:.2f}`,
             allowOverlap: true,
             align: 'left',
             verticalAlign: 'bottom',
@@ -76,18 +100,18 @@ const updateData = () => {
         };
       }
 
-      if (currentSeries[name]) {
+      if (currentSeries[String(bgmId)]) {
         // Update existing series
 
-        currentSeries[name].setData(formattedData, false, true, false);
+        currentSeries[String(bgmId)].setData(formattedData, false, true, false);
 
-        currentSeries[name].update({ zones }, false);
-        delete currentSeries[name]; // Remove from currentSeries to avoid deleting it later
+        currentSeries[String(bgmId)].update({ zones, name: legendName }, false);
+        delete currentSeries[String(bgmId)]; // Remove from currentSeries to avoid deleting it later
       } else {
         // Add new series if it does not exist
         chartInstance.value.addSeries(
           {
-            name: name,
+            name: legendName,
             id: bgmId,
             data: formattedData,
             type: 'spline',
@@ -171,6 +195,7 @@ const initializeChart = () => {
       ],
       xAxis: {
         type: 'datetime',
+        tickPixelInterval: 120,
         dateTimeLabelFormats: {
           millisecond: '%m-%d',
           second: '%m-%d',
@@ -185,7 +210,11 @@ const initializeChart = () => {
       legend: {
         useHTML: true,
         labelFormatter: function () {
-          return `${this.name} <span class="legend-link" style="color: ${BLUE}; opacity: 0.5; font-size: 11px; cursor: pointer;" >[↗]</span>`;
+          const match = this.name.match(/^(\d+\.\d{2}|N\/A)\s+(.*)$/);
+          const displayName = match
+            ? `<span style="color: ${this.color};">${match[1]}</span> ${match[2]}`
+            : this.name;
+          return `${displayName} <span class="legend-link" style="color: ${BLUE}; opacity: 0.5; font-size: 11px; cursor: pointer;" >[↗]</span>`;
         }
       },
       series: [],

--- a/src/components/charts/BattleRankChart.vue
+++ b/src/components/charts/BattleRankChart.vue
@@ -22,6 +22,12 @@ useChartTheme(chartInstance);
 
 const router = useRouter();
 
+const getLatestRank = (rankHistory = []) => {
+  if (!Array.isArray(rankHistory) || rankHistory.length === 0) return Number.POSITIVE_INFINITY;
+  const latest = Number(rankHistory[rankHistory.length - 1]?.[1]);
+  return Number.isFinite(latest) ? latest : Number.POSITIVE_INFINITY;
+};
+
 const updateData = () => {
   if (chartInstance.value) {
     // Define the plot line options
@@ -51,14 +57,27 @@ const updateData = () => {
 
     const currentSeries = {};
 
-    // Create a map of existing series by their names for easy lookup
+    // Create a map of existing series by id for reliable updates
     chartInstance.value.series.forEach((series) => {
-      currentSeries[series.name] = series;
+      const seriesId = String(series.userOptions?.id || '');
+      if (seriesId) {
+        currentSeries[seriesId] = series;
+      }
+    });
+
+    // Keep sorting local to this chart: do not mutate source data from the store.
+    const sortedHistoryData = [...props.historyData].sort((a, b) => {
+      const rankDiff = getLatestRank(a.rankHistory) - getLatestRank(b.rankHistory);
+      if (rankDiff !== 0) return rankDiff;
+      const nameA = a?.name || '';
+      const nameB = b?.name || '';
+      return nameA.localeCompare(nameB, 'zh-Hans-CN');
     });
 
     // Add or update series
-    props.historyData.forEach((seriesData) => {
+    sortedHistoryData.forEach((seriesData, index) => {
       const { name, bgmId, rankHistory, color, airDate } = seriesData;
+      const prefixedName = `#${index + 1} ${name}`;
 
       // Define zones based on airDate
       const zones = [
@@ -87,7 +106,7 @@ const updateData = () => {
           y: formattedData[lastIndex][1],
           dataLabels: {
             enabled: true,
-            format: `${name}: {y:.0f}`,
+            format: `${prefixedName}: {y:.0f}`,
             allowOverlap: true,
             align: 'left',
             verticalAlign: 'bottom',
@@ -101,22 +120,23 @@ const updateData = () => {
         };
       }
 
-      if (currentSeries[name]) {
+      if (currentSeries[String(bgmId)]) {
         // Update existing series
-        currentSeries[name].setData(formattedData, false, true, false);
-        currentSeries[name].update(
+        currentSeries[String(bgmId)].setData(formattedData, false, true, false);
+        currentSeries[String(bgmId)].update(
           {
+            name: prefixedName,
             zones: zones,
             zoneAxis: 'x' // Ensure zones are based on the x-axis
           },
           false
         );
-        delete currentSeries[name]; // Remove from currentSeries to avoid deleting it later
+        delete currentSeries[String(bgmId)]; // Remove from currentSeries to avoid deleting it later
       } else {
         // Add new series if it does not exist
         chartInstance.value.addSeries(
           {
-            name: name,
+            name: prefixedName,
             id: bgmId,
             data: formattedData,
             type: 'line',
@@ -197,7 +217,6 @@ const initializeChart = () => {
         },
 
         min: -50, // Extend axis below 0 (visually above 0 on a reversed chart)
-
         labels: {
           format: '{value:.0f}',
 
@@ -209,11 +228,16 @@ const initializeChart = () => {
       legend: {
         useHTML: true,
         labelFormatter: function () {
-          return `${this.name} <span class="legend-link" style="color: ${BLUE}; opacity: 0.5; font-size: 11px; cursor: pointer;" >[↗]</span>`;
+          const match = this.name.match(/^(#\d+)\s+(.*)$/);
+          const displayName = match
+            ? `<span style="color: ${this.color};">${match[1]}</span> ${match[2]}`
+            : this.name;
+          return `${displayName} <span class="legend-link" style="color: ${BLUE}; opacity: 0.5; font-size: 11px; cursor: pointer;" >[↗]</span>`;
         }
       },
       xAxis: {
         type: 'datetime',
+        tickPixelInterval: 120,
         dateTimeLabelFormats: {
           millisecond: '%m-%d',
           second: '%m-%d',


### PR DESCRIPTION
## Summary
- sort season score-chart series by latest score (desc) and prefix legend with current score
- sort season rank-chart series by latest rank (asc) and prefix legend with #index
- use stable series updates by `bgmId` and keep colored legend prefixes in both charts
- align score/rank chart x-axis label density via shared `tickPixelInterval`

## Notes
- sorting is local to each chart render path and does not mutate store data
- links in legends (`[↗]`) continue to route to subject pages
