### PR TITLE
Add site actions trend chart and place it on Season page

### DIFF
--- a/src/components/charts/TrendingActionsDailyChart.vue
+++ b/src/components/charts/TrendingActionsDailyChart.vue
@@ -1,0 +1,161 @@
+<script setup>
+import { onMounted, onUnmounted, ref, shallowRef, watch } from 'vue';
+import Highcharts from '@/utils/highcharts';
+import { COLORS2 } from '@/constants/colors';
+import { useChartTheme } from '@/composables/useChartTheme';
+
+const props = defineProps({
+  actionsDailySeries: {
+    type: Array,
+    required: true
+  }
+});
+
+const chartContainer = ref(null);
+const chartInstance = shallowRef(null);
+const LABELS = {
+  wish: '想看',
+  collect: '看过',
+  doing: '在看',
+  on_hold: '搁置',
+  dropped: '抛弃'
+};
+
+useChartTheme(chartInstance);
+
+const updateData = () => {
+  if (!chartInstance.value) return;
+
+  const incoming = Array.isArray(props.actionsDailySeries) ? props.actionsDailySeries : [];
+  const incomingByKey = Object.fromEntries(incoming.map((series) => [series.key, series]));
+
+  chartInstance.value.series.forEach((series) => {
+    const key = series.userOptions?.id;
+    const next = incomingByKey[key];
+    series.setData(next?.data || [], false);
+  });
+  chartInstance.value.redraw();
+};
+
+const initializeChart = () => {
+  if (chartInstance.value) {
+    chartInstance.value.destroy();
+  }
+  if (!chartContainer.value) return;
+
+  const chart = Highcharts.chart(chartContainer.value, {
+    chart: {
+      backgroundColor: null
+    },
+    xAxis: {
+      type: 'datetime',
+      dateTimeLabelFormats: {
+        millisecond: '%m-%d',
+        second: '%m-%d',
+        minute: '%m-%d',
+        hour: '%m-%d',
+        day: '%m-%d',
+        week: '%m-%d',
+        month: '%m-%d',
+        year: '%m-%d'
+      }
+    },
+    yAxis: {
+      title: {
+        text: ''
+      },
+      labels: {
+        enabled: false
+      }
+    },
+    legend: { enabled: true },
+    tooltip: {
+      shared: true,
+      formatter: function () {
+        let s = `<p style="font-size: 10px;">${Highcharts.dateFormat('%Y-%m-%d', this.x)}</p>`;
+        this.points.forEach((point) => {
+          s += `<br/><span style="color:${point.color}">●</span> ${point.series.name}`;
+        });
+        return s;
+      }
+    },
+    plotOptions: {
+      area: {
+        stacking: 'normal',
+        marker: {
+          enabled: false
+        },
+        lineWidth: 2,
+        fillOpacity: 0.25
+      },
+      series: {
+        animation: {
+          defer: 300,
+          duration: 900
+        }
+      }
+    },
+    series: [
+      {
+        type: 'area',
+        id: 'wish',
+        name: LABELS.wish,
+        data: [],
+        color: COLORS2[0]
+      },
+      {
+        type: 'area',
+        id: 'collect',
+        name: LABELS.collect,
+        data: [],
+        color: COLORS2[1]
+      },
+      {
+        type: 'area',
+        id: 'doing',
+        name: LABELS.doing,
+        data: [],
+        color: COLORS2[2]
+      },
+      {
+        type: 'area',
+        id: 'on_hold',
+        name: LABELS.on_hold,
+        data: [],
+        color: COLORS2[3]
+      },
+      {
+        type: 'area',
+        id: 'dropped',
+        name: LABELS.dropped,
+        data: [],
+        color: COLORS2[4]
+      }
+    ]
+  });
+
+  chartInstance.value = chart;
+  updateData();
+};
+
+onMounted(initializeChart);
+
+onUnmounted(() => {
+  if (chartInstance.value) {
+    chartInstance.value.destroy();
+    chartInstance.value = null;
+  }
+});
+
+watch(
+  () => props.actionsDailySeries,
+  () => {
+    updateData();
+  },
+  { deep: false }
+);
+</script>
+
+<template>
+  <div class="h-full" ref="chartContainer"></div>
+</template>

--- a/src/constants/texts.js
+++ b/src/constants/texts.js
@@ -39,6 +39,7 @@ const texts = {
   _july: '七月',
   _october: '十月',
   // Trending view texts
+  _trendingActionsDaily: '全站收藏趋势',
   _popularEntries: '热门条目',
   _increasingRank: '涨幅排行',
   _decreasingRank: '跌幅排行',

--- a/src/stores/trending.js
+++ b/src/stores/trending.js
@@ -1,6 +1,6 @@
 // Importing Pinia and other utilities
 import { defineStore } from 'pinia';
-import { fetchTrending } from '@/utils/api.js';
+import { fetchTrending, fetchTrendingActionsDaily } from '@/utils/api.js';
 import { useAppStore } from '@/stores/app.js';
 import withSmartLoadingUx from '@/utils/withSmartLoadingUx.js';
 
@@ -9,7 +9,9 @@ export const useTrendingStore = defineStore('trending', {
     up: [],
     down: [],
     done: [],
-    popular: []
+    popular: [],
+    actionsDaily: null,
+    actionsDailySeries: []
   }),
   getters: {},
   actions: {
@@ -34,6 +36,45 @@ export const useTrendingStore = defineStore('trending', {
       } catch (error) {
         console.error('Failed to fetch trending:', error);
         // Handle error appropriately
+      }
+    },
+    async fetchTrendingActionsDaily() {
+      if (this.actionsDailySeries.length > 0) return;
+      try {
+        const fetchTrendingActionsDailyWithLoading = withSmartLoadingUx(fetchTrendingActionsDaily, {
+          delay: 500,
+          minimumDisplayTime: 1000,
+          setLoadingState: useAppStore().setLongPolling
+        });
+
+        const response = await fetchTrendingActionsDailyWithLoading();
+        const payload = response.data || {};
+        const rows = Array.isArray(payload.series) ? payload.series : [];
+        const actionKeys = ['wish', 'collect', 'doing', 'on_hold', 'dropped'];
+        const chartSeries = actionKeys.map((key) => ({
+          key,
+          data: []
+        }));
+
+        this.actionsDaily = payload;
+
+        rows
+          .map((item) => ({
+            x: new Date(item.date).getTime(),
+            actions: item.actions || {}
+          }))
+          .filter((row) => Number.isFinite(row.x))
+          .sort((a, b) => a.x - b.x)
+          .forEach((row) => {
+            actionKeys.forEach((key, index) => {
+              const value = Number(row.actions[key] || 0);
+              chartSeries[index].data.push([row.x, Number.isFinite(value) ? value : 0]);
+            });
+          });
+
+        this.actionsDailySeries = chartSeries;
+      } catch (error) {
+        console.error('Failed to fetch trending actions daily:', error);
       }
     }
   }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -18,6 +18,10 @@ export const fetchTrending = () => {
   return axios.get(`${api_root}/trending`);
 };
 
+export const fetchTrendingActionsDaily = () => {
+  return axios.get(`${api_root}/trending-actions-daily`);
+};
+
 export const fetchSeason = (year, month) => {
   let url = `${api_root}/season`;
   if (year && month) {

--- a/src/views/SeasonView.vue
+++ b/src/views/SeasonView.vue
@@ -1,9 +1,11 @@
 <script setup>
 import { useSeasonStore } from '@/stores/season.js';
+import { useTrendingStore } from '@/stores/trending';
 import { storeToRefs } from 'pinia';
 import BattleChart from '@/components/charts/BattleChart.vue';
 import BattleBarChart from '@/components/charts/BattleBarChart.vue';
 import BattleRankChart from '@/components/charts/BattleRankChart.vue';
+import TrendingActionsDailyChart from '@/components/charts/TrendingActionsDailyChart.vue';
 import HintDiv from '@/components/ui/HintDiv.vue';
 import { useRoute, useRouter } from 'vue-router';
 import { onMounted, watch, computed, ref, onUnmounted } from 'vue';
@@ -11,9 +13,11 @@ import ScoreBubbleChart from '@/components/charts/ScoreBubbleChart.vue';
 import texts from '@/constants/texts';
 
 const store = useSeasonStore();
+const trendingStore = useTrendingStore();
 const route = useRoute();
 const router = useRouter();
 const { historyData, balanceData, subjectsData } = storeToRefs(store);
+const { actionsDailySeries } = storeToRefs(trendingStore);
 const showLabels = ref(false); // Set to false by default
 
 // Generate array of last 5 years
@@ -68,6 +72,7 @@ const handleKeyDown = (e) => {
 onMounted(() => {
   window.addEventListener('keydown', handleKeyDown);
   fetchSeason();
+  trendingStore.fetchTrendingActionsDaily();
 });
 
 onUnmounted(() => {
@@ -185,6 +190,17 @@ const handleSeasonChange = (event) => {
       </p>
       <div class="bleed-right-to-container-left sm:aspect-[10/5]">
         <ScoreBubbleChart :subjects="subjectsData" />
+      </div>
+    </div>
+
+    <div
+      id="season-site-trending-actions"
+      v-if="actionsDailySeries.length"
+      class="flex flex-col gap-4"
+    >
+      <h2 class="text-2xl">{{ texts._trendingActionsDaily }}</h2>
+      <div class="bleed-left-to-container-right sm:aspect-[16/6]">
+        <TrendingActionsDailyChart :actions-daily-series="actionsDailySeries" />
       </div>
     </div>
   </div>

--- a/src/views/SeasonView.vue
+++ b/src/views/SeasonView.vue
@@ -198,7 +198,7 @@ const handleSeasonChange = (event) => {
       v-if="actionsDailySeries.length"
       class="flex flex-col gap-4"
     >
-      <h2 class="text-2xl">{{ texts._trendingActionsDaily }}</h2>
+      <h2 class="text-right text-2xl">{{ texts._trendingActionsDaily }}</h2>
       <div class="bleed-left-to-container-right sm:aspect-[16/6]">
         <TrendingActionsDailyChart :actions-daily-series="actionsDailySeries" />
       </div>

--- a/src/views/TrendingView.vue
+++ b/src/views/TrendingView.vue
@@ -16,60 +16,62 @@ const formatData = (history) =>
 </script>
 
 <template>
-  <div class="xl: grid grid-cols-1 gap-32 px-4 pt-14 xl:grid-cols-3" v-if="done.length">
-    <div v-for="(items, index) in [done, up, down]" :key="index" class="flex flex-col gap-16">
-      <div
-        class="sticky top-0 z-10 flex w-full bg-background py-4 transition-[background-color] duration-300"
-      >
-        <h2
-          :id="['popular', 'up', 'down'][index]"
-          class="mr-auto text-2xl tracking-wider first-letter:text-3xl"
-          :class="['bg-gold', 'bg-pink', 'bg-blue'][index]"
+  <div class="@container mt-14 flex flex-col gap-20 px-4 pt-0">
+    <div class="xl: grid grid-cols-1 gap-32 xl:grid-cols-3" v-if="done.length">
+      <div v-for="(items, index) in [done, up, down]" :key="index" class="flex flex-col gap-16">
+        <div
+          class="sticky top-0 z-10 flex w-full bg-background py-4 transition-[background-color] duration-300"
         >
-          <a :href="'#' + ['popular', 'up', 'down'][index]" class="anchor-link">
-            {{ [texts._popularEntries, texts._increasingRank, texts._decreasingRank][index] }}
-          </a>
-        </h2>
-      </div>
+          <h2
+            :id="['popular', 'up', 'down'][index]"
+            class="mr-auto text-2xl tracking-wider first-letter:text-3xl"
+            :class="['bg-gold', 'bg-pink', 'bg-blue'][index]"
+          >
+            <a :href="'#' + ['popular', 'up', 'down'][index]" class="anchor-link">
+              {{ [texts._popularEntries, texts._increasingRank, texts._decreasingRank][index] }}
+            </a>
+          </h2>
+        </div>
 
-      <ol class="flex list-decimal flex-col gap-16 xl:gap-8">
-        <li v-for="item in items" :key="item.bgmId">
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-8">
-              <div class="text-2xl">
-                <RouterLink
-                  class="line-clamp-1"
-                  :class="['hover:bg-gold', 'hover:bg-pink', 'hover:bg-blue'][index]"
-                  :to="'/subject/' + item.bgmId"
-                  :title="item.subject.name_cn || item.subject.name"
-                  >{{ item.subject.name_cn || item.subject.name }}</RouterLink
-                >
+        <ol class="flex list-decimal flex-col gap-16 xl:gap-8">
+          <li v-for="item in items" :key="item.bgmId">
+            <div class="grid grid-cols-12 gap-4">
+              <div class="col-span-8">
+                <div class="text-2xl">
+                  <RouterLink
+                    class="line-clamp-1"
+                    :class="['hover:bg-gold', 'hover:bg-pink', 'hover:bg-blue'][index]"
+                    :to="'/subject/' + item.bgmId"
+                    :title="item.subject.name_cn || item.subject.name"
+                    >{{ item.subject.name_cn || item.subject.name }}</RouterLink
+                  >
+                </div>
+                <div class="text-md line-clamp-1" :title="item.subject.name">
+                  {{ item.subject.name }}
+                </div>
               </div>
-              <div class="text-md line-clamp-1" :title="item.subject.name">
-                {{ item.subject.name }}
+              <div class="col-span-4 text-2xl">
+                <div class="flex flex-col items-end">
+                  <DeltaDisplay :delta="item.score" />
+                  <span
+                    class="ml-2 px-1 text-sm text-white"
+                    :style="{
+                      color: COLORS10[Math.round(item.history[item.history.length - 1].score)]
+                    }"
+                    >{{ item.history[item.history.length - 1].score }}</span
+                  >
+                </div>
+              </div>
+              <div class="col-span-12 aspect-[24/8]">
+                <MiniScoreChart
+                  :color="item.score >= 0 ? PINK : BLUE"
+                  :history-data="formatData(item.history)"
+                />
               </div>
             </div>
-            <div class="col-span-4 text-2xl">
-              <div class="flex flex-col items-end">
-                <DeltaDisplay :delta="item.score" />
-                <span
-                  class="ml-2 px-1 text-sm text-white"
-                  :style="{
-                    color: COLORS10[Math.round(item.history[item.history.length - 1].score)]
-                  }"
-                  >{{ item.history[item.history.length - 1].score }}</span
-                >
-              </div>
-            </div>
-            <div class="col-span-12 aspect-[24/8]">
-              <MiniScoreChart
-                :color="item.score >= 0 ? PINK : BLUE"
-                :history-data="formatData(item.history)"
-              />
-            </div>
-          </div>
-        </li>
-      </ol>
+          </li>
+        </ol>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- add fetchTrendingActionsDaily API support and trending store mapping for the new actions payload shape (wish, collect, doing, on_hold, dropped)
- add TrendingActionsDailyChart as a stacked area Highcharts component with theme-aware styling
- move the new chart off /trending and render it as the last chart section on /season
- update chart label text to 全站收藏趋势 and keep the requested tooltip/axis display behavior

## Notes
- chart section is currently left-bleed on /season with sm:aspect-[16/6]
- for this left-bleed section, the title is right-aligned to match the page style rule
- existing /trending ranking lists remain unchanged
- project build succeeds after these changes (npm run build)