### PR TITLE
Fix rank legend and move trending actions chart

### DIFF
--- a/src/components/charts/BattleRankChart.vue
+++ b/src/components/charts/BattleRankChart.vue
@@ -75,9 +75,11 @@ const updateData = () => {
     });
 
     // Add or update series
-    sortedHistoryData.forEach((seriesData, index) => {
+    sortedHistoryData.forEach((seriesData) => {
       const { name, bgmId, rankHistory, color, airDate } = seriesData;
-      const prefixedName = `#${index + 1} ${name}`;
+      const latestRank = getLatestRank(rankHistory);
+      const rankPrefix = Number.isFinite(latestRank) ? `#${Math.round(latestRank)}` : '#N/A';
+      const prefixedName = `${rankPrefix} ${name}`;
 
       // Define zones based on airDate
       const zones = [
@@ -228,7 +230,7 @@ const initializeChart = () => {
       legend: {
         useHTML: true,
         labelFormatter: function () {
-          const match = this.name.match(/^(#\d+)\s+(.*)$/);
+          const match = this.name.match(/^(#(?:\d+|N\/A))\s+(.*)$/);
           const displayName = match
             ? `<span style="color: ${this.color};">${match[1]}</span> ${match[2]}`
             : this.name;

--- a/src/stores/season.js
+++ b/src/stores/season.js
@@ -5,6 +5,28 @@ import { useAppStore } from '@/stores/app.js';
 import withSmartLoadingUx from '@/utils/withSmartLoadingUx.js';
 import dayjs from 'dayjs';
 
+const getCurrentSeasonMonth = (month) => {
+  if (month >= 1 && month <= 3) return 1;
+  if (month >= 4 && month <= 6) return 4;
+  if (month >= 7 && month <= 9) return 7;
+  return 10;
+};
+
+const resolveSeasonParams = (year, month) => {
+  const parsedYear = Number.parseInt(year, 10);
+  const parsedMonth = Number.parseInt(month, 10);
+
+  if (Number.isFinite(parsedYear) && Number.isFinite(parsedMonth)) {
+    return { year: parsedYear, month: parsedMonth };
+  }
+
+  const now = new Date();
+  return {
+    year: now.getFullYear(),
+    month: getCurrentSeasonMonth(now.getMonth() + 1)
+  };
+};
+
 export const useSeasonStore = defineStore('season', {
   state: () => ({
     season: [],
@@ -110,21 +132,25 @@ export const useSeasonStore = defineStore('season', {
 
   actions: {
     async fetchSeason(year, month) {
-      const requestKey = `${year || 'current'}-${month || 'current'}-${Date.now()}`;
+      const seasonParams = resolveSeasonParams(year, month);
+      const requestKey = `${seasonParams.year}-${seasonParams.month}-${Date.now()}`;
       this.currentRequestKey = requestKey;
       try {
-        const fetchSeasonWithLoading = withSmartLoadingUx(() => fetchSeason(year, month), {
-          delay: 500,
-          minimumDisplayTime: 1000,
-          setLoadingState: useAppStore().setLongPolling
-        });
+        const fetchSeasonWithLoading = withSmartLoadingUx(
+          () => fetchSeason(seasonParams.year, seasonParams.month),
+          {
+            delay: 500,
+            minimumDisplayTime: 1000,
+            setLoadingState: useAppStore().setLongPolling
+          }
+        );
 
         const seasonResponse = await fetchSeasonWithLoading();
         if (this.currentRequestKey !== requestKey) return;
         this.season = Array.isArray(seasonResponse.data) ? seasonResponse.data : [];
         this.analysis = null;
 
-        fetchSeasonAnalysis(year, month)
+        fetchSeasonAnalysis(seasonParams.year, seasonParams.month)
           .then((analysisResponse) => {
             if (this.currentRequestKey !== requestKey) return;
             this.analysis = analysisResponse.data || null;

--- a/src/stores/trending.js
+++ b/src/stores/trending.js
@@ -50,6 +50,12 @@ export const useTrendingStore = defineStore('trending', {
         const response = await fetchTrendingActionsDailyWithLoading();
         const payload = response.data || {};
         const rows = Array.isArray(payload.series) ? payload.series : [];
+        const latestDate = rows.reduce((max, item) => {
+          const value = item?.date;
+          if (!value) return max;
+          if (!max) return value;
+          return value > max ? value : max;
+        }, '');
         const actionKeys = ['wish', 'collect', 'doing', 'on_hold', 'dropped'];
         const chartSeries = actionKeys.map((key) => ({
           key,
@@ -59,6 +65,7 @@ export const useTrendingStore = defineStore('trending', {
         this.actionsDaily = payload;
 
         rows
+          .filter((item) => item?.date && item.date !== latestDate)
           .map((item) => ({
             x: new Date(item.date).getTime(),
             actions: item.actions || {}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -23,19 +23,17 @@ export const fetchTrendingActionsDaily = () => {
 };
 
 export const fetchSeason = (year, month) => {
-  let url = `${api_root}/season`;
-  if (year && month) {
-    url += `/${year}/${month}`;
+  if (!year || !month) {
+    throw new Error('fetchSeason requires both year and month');
   }
-  return axios.get(url);
+  return axios.get(`${api_root}/season/${year}/${month}`);
 };
 
 export const fetchSeasonAnalysis = (year, month) => {
-  let url = `${api_root}/season/analysis`;
-  if (year && month) {
-    url = `${api_root}/season/${year}/${month}/analysis`;
+  if (!year || !month) {
+    throw new Error('fetchSeasonAnalysis requires both year and month');
   }
-  return axios.get(url);
+  return axios.get(`${api_root}/season/${year}/${month}/analysis`);
 };
 
 export const fetchHistory = () => {

--- a/src/views/SeasonView.vue
+++ b/src/views/SeasonView.vue
@@ -1,11 +1,9 @@
 <script setup>
 import { useSeasonStore } from '@/stores/season.js';
-import { useTrendingStore } from '@/stores/trending';
 import { storeToRefs } from 'pinia';
 import BattleChart from '@/components/charts/BattleChart.vue';
 import BattleBarChart from '@/components/charts/BattleBarChart.vue';
 import BattleRankChart from '@/components/charts/BattleRankChart.vue';
-import TrendingActionsDailyChart from '@/components/charts/TrendingActionsDailyChart.vue';
 import HintDiv from '@/components/ui/HintDiv.vue';
 import { useRoute, useRouter } from 'vue-router';
 import { onMounted, watch, computed, ref, onUnmounted } from 'vue';
@@ -13,11 +11,9 @@ import ScoreBubbleChart from '@/components/charts/ScoreBubbleChart.vue';
 import texts from '@/constants/texts';
 
 const store = useSeasonStore();
-const trendingStore = useTrendingStore();
 const route = useRoute();
 const router = useRouter();
 const { historyData, balanceData, subjectsData, analysis } = storeToRefs(store);
-const { actionsDailySeries } = storeToRefs(trendingStore);
 const showLabels = ref(false); // Set to false by default
 const splitNearMiddleByStop = (text) => {
   const content = text.trim();
@@ -110,7 +106,6 @@ const handleKeyDown = (e) => {
 onMounted(() => {
   window.addEventListener('keydown', handleKeyDown);
   fetchSeason();
-  trendingStore.fetchTrendingActionsDaily();
 });
 
 onUnmounted(() => {
@@ -261,17 +256,6 @@ const handleSeasonChange = (event) => {
       </div>
       <div class="bleed-right-to-container-left sm:aspect-[10/5]">
         <ScoreBubbleChart :subjects="subjectsData" />
-      </div>
-    </div>
-
-    <div
-      id="season-site-trending-actions"
-      v-if="actionsDailySeries.length"
-      class="flex flex-col gap-4"
-    >
-      <h2 class="text-right text-2xl">{{ texts._trendingActionsDaily }}</h2>
-      <div class="bleed-left-to-container-right sm:aspect-[16/6]">
-        <TrendingActionsDailyChart :actions-daily-series="actionsDailySeries" />
       </div>
     </div>
   </div>

--- a/src/views/TrendingView.vue
+++ b/src/views/TrendingView.vue
@@ -2,14 +2,16 @@
 import { useTrendingStore } from '@/stores/trending';
 import { storeToRefs } from 'pinia';
 import MiniScoreChart from '@/components/charts/MiniScoreChart.vue';
+import TrendingActionsDailyChart from '@/components/charts/TrendingActionsDailyChart.vue';
 import { BLUE, COLORS10, PINK } from '@/constants/colors.js';
 import DeltaDisplay from '@/components/DeltaDisplay.vue';
 import texts from '@/constants/texts.js';
 
 const store = useTrendingStore();
-const { up, down, done } = storeToRefs(store);
+const { up, down, done, actionsDailySeries } = storeToRefs(store);
 
 store.fetchTrending();
+store.fetchTrendingActionsDaily();
 
 const formatData = (history) =>
   history.map((item) => ({ x: new Date(item.recordedAt), y: item.score }));
@@ -71,6 +73,17 @@ const formatData = (history) =>
             </div>
           </li>
         </ol>
+      </div>
+    </div>
+
+    <div
+      id="trending-site-trending-actions"
+      v-if="actionsDailySeries.length"
+      class="flex flex-col gap-4"
+    >
+      <h2 class="text-right text-2xl">{{ texts._trendingActionsDaily }}</h2>
+      <div class="bleed-both-to-viewport sm:aspect-[16/6]">
+        <TrendingActionsDailyChart :actions-daily-series="actionsDailySeries" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- fix /season rank chart legend to display each title's latest actual rank (#<rank>) instead of list index
- move 全站收藏趋势 chart section from /season to the bottom of /trending
- update /trending trend chart wrapper to use both-side bleed layout
- filter out the last day in trending actions daily series so partial latest-day data is not charted

## Notes
- last-day exclusion is based on the latest date present in API series data, avoiding timezone/date-format mismatch issues
- SeasonView no longer fetches or renders the trending actions daily chart