### PR TITLE
Animate season charts on first in-view render

### DIFF
--- a/src/components/charts/BattleBarChart.vue
+++ b/src/components/charts/BattleBarChart.vue
@@ -3,19 +3,26 @@ import { ref, onMounted, onUnmounted, watch, shallowRef } from 'vue';
 import Highcharts from '@/utils/highcharts';
 import { BLUE, PINK } from '@/constants/colors.js';
 import { useChartTheme } from '@/composables/useChartTheme';
+import { useInViewOnce } from '@/composables/useInViewOnce';
 
 const props = defineProps({
   balanceData: {
     type: Object,
     required: true
+  },
+  animateWhenInView: {
+    type: Boolean,
+    default: false
   }
 });
 
 const chartContainer = ref(null);
 const chartInstance = shallowRef(null);
 useChartTheme(chartInstance);
+const { isInViewOnce } = useInViewOnce(chartContainer, { enabled: props.animateWhenInView });
 
 const updateData = () => {
+  if (props.animateWhenInView && !isInViewOnce.value) return;
   if (chartInstance.value) {
     chartInstance.value.yAxis[0].setExtremes(
       -props.balanceData.extreme,
@@ -64,10 +71,12 @@ const initializeChart = () => {
       plotOptions: {
         series: {
           stacking: 'normal',
-          animation: {
-            defer: 1500,
-            duration: 1000
-          },
+          animation:
+            props.animateWhenInView && !isInViewOnce.value
+              ? false
+              : {
+                  duration: 1000
+                },
           pointWidth: 20 // Add this line to set a fixed width for bars
           // or use pointPadding: 0.1, // to set the padding between bars
         }
@@ -121,6 +130,15 @@ watch(
     updateData();
   },
   { deep: true }
+);
+
+watch(
+  () => isInViewOnce.value,
+  (visible) => {
+    if (props.animateWhenInView && visible) {
+      initializeChart();
+    }
+  }
 );
 </script>
 

--- a/src/components/charts/BattleChart.vue
+++ b/src/components/charts/BattleChart.vue
@@ -4,6 +4,7 @@ import Highcharts from '@/utils/highcharts';
 import { BLUE, COLORS10 } from '@/constants/colors';
 import { useRouter } from 'vue-router';
 import { useChartTheme } from '@/composables/useChartTheme';
+import { useInViewOnce } from '@/composables/useInViewOnce';
 
 const props = defineProps({
   historyData: {
@@ -13,6 +14,10 @@ const props = defineProps({
   showLabels: {
     type: Boolean,
     default: false
+  },
+  animateWhenInView: {
+    type: Boolean,
+    default: false
   }
 });
 
@@ -20,6 +25,7 @@ const chartContainer = ref(null);
 const chartInstance = shallowRef(null);
 const router = useRouter();
 useChartTheme(chartInstance);
+const { isInViewOnce } = useInViewOnce(chartContainer, { enabled: props.animateWhenInView });
 
 const getLatestScore = (scoreHistory = []) => {
   if (!Array.isArray(scoreHistory) || scoreHistory.length === 0) return Number.NEGATIVE_INFINITY;
@@ -28,6 +34,7 @@ const getLatestScore = (scoreHistory = []) => {
 };
 
 const updateData = () => {
+  if (props.animateWhenInView && !isInViewOnce.value) return;
   if (chartInstance.value) {
     const currentSeries = {};
 
@@ -158,10 +165,12 @@ const initializeChart = () => {
           }
         },
         series: {
-          animation: {
-            defer: 500,
-            duration: 1000
-          },
+          animation:
+            props.animateWhenInView && !isInViewOnce.value
+              ? false
+              : {
+                  duration: 1000
+                },
           states: {
             inactive: {
               opacity: 0.5
@@ -253,6 +262,15 @@ watch(
   () => props.showLabels,
   () => {
     updateData();
+  }
+);
+
+watch(
+  () => isInViewOnce.value,
+  (visible) => {
+    if (props.animateWhenInView && visible) {
+      initializeChart();
+    }
   }
 );
 </script>

--- a/src/components/charts/BattleRankChart.vue
+++ b/src/components/charts/BattleRankChart.vue
@@ -4,6 +4,7 @@ import Highcharts from '@/utils/highcharts';
 import { BLUE, COLORS10 } from '@/constants/colors';
 import { useRouter } from 'vue-router';
 import { useChartTheme } from '@/composables/useChartTheme';
+import { useInViewOnce } from '@/composables/useInViewOnce';
 
 const props = defineProps({
   historyData: {
@@ -13,12 +14,17 @@ const props = defineProps({
   showLabels: {
     type: Boolean,
     default: false
+  },
+  animateWhenInView: {
+    type: Boolean,
+    default: false
   }
 });
 
 const chartContainer = ref(null);
 const chartInstance = shallowRef(null);
 useChartTheme(chartInstance);
+const { isInViewOnce } = useInViewOnce(chartContainer, { enabled: props.animateWhenInView });
 
 const router = useRouter();
 
@@ -29,6 +35,7 @@ const getLatestRank = (rankHistory = []) => {
 };
 
 const updateData = () => {
+  if (props.animateWhenInView && !isInViewOnce.value) return;
   if (chartInstance.value) {
     // Define the plot line options
     const epPlotOptions = {
@@ -188,10 +195,12 @@ const initializeChart = () => {
           }
         },
         series: {
-          animation: {
-            defer: 500,
-            duration: 1000
-          },
+          animation:
+            props.animateWhenInView && !isInViewOnce.value
+              ? false
+              : {
+                  duration: 1000
+                },
           states: {
             inactive: {
               opacity: 0.5
@@ -287,6 +296,15 @@ watch(
   () => props.showLabels,
   () => {
     updateData();
+  }
+);
+
+watch(
+  () => isInViewOnce.value,
+  (visible) => {
+    if (props.animateWhenInView && visible) {
+      initializeChart();
+    }
   }
 );
 </script>

--- a/src/components/charts/ScoreBubbleChart.vue
+++ b/src/components/charts/ScoreBubbleChart.vue
@@ -7,16 +7,22 @@ import { ref, onMounted, onUnmounted, watch, shallowRef } from 'vue';
 import Highcharts from '@/utils/highcharts';
 import { useChartTheme } from '@/composables/useChartTheme';
 import { BLUE, PINK } from '@/constants/colors';
+import { useInViewOnce } from '@/composables/useInViewOnce';
 
 const props = defineProps({
   subjects: {
     type: Array,
     required: true
+  },
+  animateWhenInView: {
+    type: Boolean,
+    default: false
   }
 });
 
 const chartContainer = ref(null);
 const chartInstance = shallowRef(null);
+const { isInViewOnce } = useInViewOnce(chartContainer, { enabled: props.animateWhenInView });
 
 useChartTheme(chartInstance);
 
@@ -38,6 +44,7 @@ const getColorByStd = (std) => {
 };
 
 const updateData = () => {
+  if (props.animateWhenInView && !isInViewOnce.value) return;
   if (chartInstance.value) {
     const maxTotal = Math.max(...props.subjects.map((subject) => subject.total));
 
@@ -82,9 +89,12 @@ const initializeChart = () => {
       plotOptions: {
         bubble: {
           // Changed from scatter to bubble
-          animation: {
-            enabled: false
-          },
+          animation:
+            props.animateWhenInView && !isInViewOnce.value
+              ? false
+              : {
+                  duration: 900
+                },
           minSize: 3,
           maxSize: 25,
           zMin: 0,
@@ -147,5 +157,14 @@ watch(
     updateData();
   },
   { deep: true }
+);
+
+watch(
+  () => isInViewOnce.value,
+  (visible) => {
+    if (props.animateWhenInView && visible) {
+      initializeChart();
+    }
+  }
 );
 </script>

--- a/src/composables/useInViewOnce.js
+++ b/src/composables/useInViewOnce.js
@@ -1,0 +1,64 @@
+import { onMounted, onUnmounted, ref } from 'vue';
+
+export const useInViewOnce = (targetRef, options = {}) => {
+  const { enabled = true, threshold = 0.2, root = null, rootMargin = '0px' } = options;
+  const isInViewOnce = ref(!enabled);
+  let observer = null;
+
+  const stop = () => {
+    if (observer) {
+      observer.disconnect();
+      observer = null;
+    }
+  };
+
+  onMounted(() => {
+    if (!enabled) {
+      isInViewOnce.value = true;
+      return;
+    }
+
+    if (typeof window === 'undefined') {
+      isInViewOnce.value = true;
+      return;
+    }
+
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      isInViewOnce.value = true;
+      return;
+    }
+
+    if (!('IntersectionObserver' in window)) {
+      isInViewOnce.value = true;
+      return;
+    }
+
+    const element = targetRef.value;
+    if (!element) {
+      isInViewOnce.value = true;
+      return;
+    }
+
+    observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!isInViewOnce.value && entry.isIntersecting) {
+            isInViewOnce.value = true;
+            stop();
+          }
+        });
+      },
+      { root, rootMargin, threshold }
+    );
+
+    observer.observe(element);
+  });
+
+  onUnmounted(() => {
+    stop();
+  });
+
+  return {
+    isInViewOnce
+  };
+};

--- a/src/views/SeasonView.vue
+++ b/src/views/SeasonView.vue
@@ -206,7 +206,11 @@ const handleSeasonChange = (event) => {
       </div>
 
       <div class="bleed-left-to-container-right sm:aspect-[16/10]">
-        <BattleChart :historyData="historyData" :showLabels="showLabels" />
+        <BattleChart
+          :historyData="historyData"
+          :showLabels="showLabels"
+          :animate-when-in-view="true"
+        />
       </div>
     </div>
 
@@ -221,7 +225,11 @@ const handleSeasonChange = (event) => {
         </p>
       </div>
       <div class="bleed-right-to-container-left sm:aspect-[16/10]">
-        <BattleRankChart :historyData="historyData" :showLabels="showLabels" />
+        <BattleRankChart
+          :historyData="historyData"
+          :showLabels="showLabels"
+          :animate-when-in-view="true"
+        />
       </div>
     </div>
 
@@ -237,7 +245,7 @@ const handleSeasonChange = (event) => {
         </p>
       </div>
       <div class="bleed-left-to-container-right sm:aspect-[10/5]">
-        <BattleBarChart :balanceData="balanceData" />
+        <BattleBarChart :balanceData="balanceData" :animate-when-in-view="true" />
       </div>
     </div>
 
@@ -255,7 +263,7 @@ const handleSeasonChange = (event) => {
         </p>
       </div>
       <div class="bleed-right-to-container-left sm:aspect-[10/5]">
-        <ScoreBubbleChart :subjects="subjectsData" />
+        <ScoreBubbleChart :subjects="subjectsData" :animate-when-in-view="true" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add reusable useInViewOnce composable based on IntersectionObserver with safe fallbacks
- add optional animateWhenInView prop to season chart components and gate first render until visible
- enable in-view animation for all 4 /season charts from SeasonView
- remove per-chart animation start delays so animation starts immediately when in view

## Notes
- behavior is play-once per chart instance per page load
- reduced-motion users and environments without IntersectionObserver fall back to immediate render
- no backend or API contract changes